### PR TITLE
Add Kafka-based wiki pipeline project with Docker Compose and Kubernetes manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+env/
+.env/
+venv/
+.venv/
+.idea/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.idea/
+*.DS_Store

--- a/wiki-kafka/.idea/inspectionProfiles/profiles_settings.xml
+++ b/wiki-kafka/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/wiki-kafka/.idea/kafka-docker.iml
+++ b/wiki-kafka/.idea/kafka-docker.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/wiki-kafka/.idea/misc.xml
+++ b/wiki-kafka/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.11 (inventory-management-system)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (inventory-management-system)" project-jdk-type="Python SDK" />
+</project>

--- a/wiki-kafka/.idea/modules.xml
+++ b/wiki-kafka/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/kafka-docker.iml" filepath="$PROJECT_DIR$/.idea/kafka-docker.iml" />
+    </modules>
+  </component>
+</project>

--- a/wiki-kafka/.idea/workspace.xml
+++ b/wiki-kafka/.idea/workspace.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="799d8749-f17d-474b-8f79-fda70661d956" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 8
+}]]></component>
+  <component name="ProjectId" id="2uN6qabh6hJqmOpc5NFg1J802vB" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "last_opened_file_path": "C:/Users/Vinodh Raj S/Documents/kafka-docker"
+  }
+}]]></component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-python-sdk-975db3bf15a3-31b6be0877a2-com.jetbrains.pycharm.community.sharedIndexes.bundled-PC-241.18034.82" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="799d8749-f17d-474b-8f79-fda70661d956" name="Changes" comment="" />
+      <created>1742076876861</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1742076876861</updated>
+    </task>
+    <servers />
+  </component>
+</project>

--- a/wiki-kafka/docker-compose.yml
+++ b/wiki-kafka/docker-compose.yml
@@ -1,0 +1,90 @@
+version: "3.8"
+
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    networks:
+      - kafka-network
+
+  kafka:
+    image: wurstmeister/kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+    depends_on:
+      - zookeeper
+    networks:
+      - kafka-network
+
+  kafka-connect:
+    image: confluentinc/cp-kafka-connect:latest
+    container_name: kafka-connect
+    ports:
+      - "8083:8083"
+    environment:
+      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_BOOTSTRAP_SERVERS: kafka:9092
+      CONNECT_REST_ADVERTISED_HOST_NAME: kafka-connect
+      CONNECT_GROUP_ID: connect-cluster
+      CONNECT_CONFIG_STORAGE_TOPIC: connect-configs
+      CONNECT_OFFSET_STORAGE_TOPIC: connect-offsets
+      CONNECT_STATUS_STORAGE_TOPIC: connect-status
+      CONNECT_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_LOG4J_ROOT_LOGLEVEL: INFO
+      CONNECT_PLUGIN_PATH: /usr/share/java,/usr/share/confluent-hub-components
+    depends_on:
+      - kafka
+    networks:
+      - kafka-network
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+    ports:
+      - "9200:9200"
+    networks:
+      - kafka-network
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.17.0
+    container_name: kibana
+    ports:
+      - "5601:5601"
+    depends_on:
+      - elasticsearch
+    networks:
+      - kafka-network
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    ports:
+      - "8081:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+    depends_on:
+      - kafka
+    networks:
+      - kafka-network
+
+networks:
+  kafka-network:
+    driver: bridge

--- a/wiki-kafka/k8s/elasticsearch.yaml
+++ b/wiki-kafka/k8s/elasticsearch.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+spec:
+  ports:
+  - port: 9200
+  selector:
+    app: elasticsearch
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elasticsearch
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      containers:
+      - name: elasticsearch
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+        ports:
+        - containerPort: 9200
+        env:
+        - name: discovery.type
+          value: single-node
+        - name: ES_JAVA_OPTS
+          value: -Xms512m -Xmx512m

--- a/wiki-kafka/k8s/kafka-connect.yaml
+++ b/wiki-kafka/k8s/kafka-connect.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-connect
+spec:
+  ports:
+  - port: 8083
+  selector:
+    app: kafka-connect
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-connect
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-connect
+  template:
+    metadata:
+      labels:
+        app: kafka-connect
+    spec:
+      containers:
+      - name: kafka-connect
+        image: confluentinc/cp-kafka-connect:latest
+        ports:
+        - containerPort: 8083
+        env:
+        - name: CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR
+          value: "1"
+        - name: CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR
+          value: "1"
+        - name: CONNECT_STATUS_STORAGE_REPLICATION_FACTOR
+          value: "1"
+        - name: CONNECT_BOOTSTRAP_SERVERS
+          value: kafka:9092
+        - name: CONNECT_REST_ADVERTISED_HOST_NAME
+          value: kafka-connect
+        - name: CONNECT_GROUP_ID
+          value: connect-cluster
+        - name: CONNECT_CONFIG_STORAGE_TOPIC
+          value: connect-configs
+        - name: CONNECT_OFFSET_STORAGE_TOPIC
+          value: connect-offsets
+        - name: CONNECT_STATUS_STORAGE_TOPIC
+          value: connect-status
+        - name: CONNECT_KEY_CONVERTER
+          value: org.apache.kafka.connect.json.JsonConverter
+        - name: CONNECT_VALUE_CONVERTER
+          value: org.apache.kafka.connect.json.JsonConverter
+        - name: CONNECT_INTERNAL_KEY_CONVERTER
+          value: org.apache.kafka.connect.json.JsonConverter
+        - name: CONNECT_INTERNAL_VALUE_CONVERTER
+          value: org.apache.kafka.connect.json.JsonConverter
+        - name: CONNECT_LOG4J_ROOT_LOGLEVEL
+          value: INFO
+        - name: CONNECT_PLUGIN_PATH
+          value: /usr/share/java,/usr/share/confluent-hub-components

--- a/wiki-kafka/k8s/kafka-ui.yaml
+++ b/wiki-kafka/k8s/kafka-ui.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-ui
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: kafka-ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-ui
+  template:
+    metadata:
+      labels:
+        app: kafka-ui
+    spec:
+      containers:
+      - name: kafka-ui
+        image: provectuslabs/kafka-ui:latest
+        ports:
+        - containerPort: 8080
+        env:
+        - name: KAFKA_CLUSTERS_0_NAME
+          value: local
+        - name: KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS
+          value: kafka:9092
+        - name: KAFKA_CLUSTERS_0_ZOOKEEPER
+          value: zookeeper:2181

--- a/wiki-kafka/k8s/kafka-wiki-pipeline.yaml
+++ b/wiki-kafka/k8s/kafka-wiki-pipeline.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wiki-producer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wiki-producer
+  template:
+    metadata:
+      labels:
+        app: wiki-producer
+    spec:
+      containers:
+      - name: wiki-producer
+        image: amsg08/wiki-producer:latest
+        env:
+        - name: KAFKA_BROKER
+          value: "kafka:9092"
+        - name: ELASTICSEARCH_HOST
+          value: "http://elasticsearch:9200"
+        - name: TOPIC_NAME
+          value: "wikipedia-events"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wiki-stream-processor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wiki-stream-processor
+  template:
+    metadata:
+      labels:
+        app: wiki-stream-processor
+    spec:
+      containers:
+      - name: wiki-stream-processor
+        image: amsg08/wiki-stream-processor:latest
+        env:
+        - name: KAFKA_BROKER
+          value: "kafka:9092"
+        - name: ELASTICSEARCH_HOST
+          value: "http://elasticsearch:9200"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wiki-producer-service
+spec:
+  selector:
+    app: wiki-producer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wiki-stream-processor-service
+spec:
+  selector:
+    app: wiki-stream-processor
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/wiki-kafka/k8s/kafka.yaml
+++ b/wiki-kafka/k8s/kafka.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+spec:
+  ports:
+  - port: 9092
+  selector:
+    app: kafka
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+      - name: kafka
+        image: wurstmeister/kafka
+        ports:
+        - containerPort: 9092
+        env:
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: zookeeper:2181
+        - name: KAFKA_LISTENERS
+          value: PLAINTEXT://0.0.0.0:9092
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: PLAINTEXT://kafka:9092
+        - name: KAFKA_BROKER_ID
+          value: "1"
+        - name: KAFKA_PORT
+          value: "9092"

--- a/wiki-kafka/k8s/kibana.yaml
+++ b/wiki-kafka/k8s/kibana.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana
+spec:
+  ports:
+  - port: 5601
+  selector:
+    app: kibana
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kibana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kibana
+  template:
+    metadata:
+      labels:
+        app: kibana
+    spec:
+      containers:
+      - name: kibana
+        image: docker.elastic.co/kibana/kibana:7.17.0
+        ports:
+        - containerPort: 5601
+        env:
+        - name: ELASTICSEARCH_HOSTS
+          value: "http://elasticsearch:9200"

--- a/wiki-kafka/k8s/wiki-processor.yaml
+++ b/wiki-kafka/k8s/wiki-processor.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wiki-processor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wiki-processor
+  template:
+    metadata:
+      labels:
+        app: wiki-processor
+    spec:
+      containers:
+      - name: wiki-processor
+        image: amsg08/wiki-processor:latest  # Your DockerHub image
+        env:
+        - name: ELASTICSEARCH_HOST
+          value: http://elasticsearch:9200
+        - name: KAFKA_BROKER
+          value: kafka:9092
+        - name: TOPIC_NAME
+          value: wikipedia-events
+        - name: FILTERED_TOPIC_NAME
+          value: filtered-wikipedia-events
+        - name: ES_INDEX
+          value: filtered-wikipedia-events
+        # Optional: if wiki-processor.py is the entry point
+        command: ["faust", "-A", "wiki_stream_processor", "worker", "-l", "info"]
+

--- a/wiki-kafka/k8s/wiki-producer.yaml
+++ b/wiki-kafka/k8s/wiki-producer.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wiki-producer
+  labels:
+    app: wiki-producer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wiki-producer
+  template:
+    metadata:
+      labels:
+        app: wiki-producer
+    spec:
+      restartPolicy: Always
+      containers:
+      - name: wiki-producer
+        image: amsg08/wiki-producer:latest
+        env:
+        - name: KAFKA_BROKER
+          value: kafka:9092
+        - name: TOPIC_NAME
+          value: wikipedia-events
+        - name: ELASTICSEARCH_HOST
+          value: http://elasticsearch:9200
+        command: ["python", "wiki_producer.py"]
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+        imagePullPolicy: Always

--- a/wiki-kafka/k8s/zookeeper.yaml
+++ b/wiki-kafka/k8s/zookeeper.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+spec:
+  ports:
+  - port: 2181
+  selector:
+    app: zookeeper
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zookeeper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zookeeper
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+      - name: zookeeper
+        image: wurstmeister/zookeeper
+        ports:
+        - containerPort: 2181

--- a/wiki-kafka/wiki_producer/Dockerfile
+++ b/wiki-kafka/wiki_producer/Dockerfile
@@ -1,0 +1,22 @@
+# Base Image with Python 3.9
+FROM python:3.8-slim
+
+# Environment variables
+ENV PYTHONDONTWRITEBYTECODE = 1
+ENV PYTHONUNBUFFERED = 1
+
+# Set work directory
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y gcc libpq-dev && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Command to run producer
+CMD ["python", "wiki_producer.py"]

--- a/wiki-kafka/wiki_producer/requirements.txt
+++ b/wiki-kafka/wiki_producer/requirements.txt
@@ -1,0 +1,4 @@
+kafka-python==2.0.2
+sseclient-py==1.7.2
+requests==2.31.0
+elasticsearch==7.17.0

--- a/wiki-kafka/wiki_producer/wiki_producer.py
+++ b/wiki-kafka/wiki_producer/wiki_producer.py
@@ -1,0 +1,79 @@
+import os
+import json
+import time
+import requests
+from kafka import KafkaProducer, errors
+from sseclient import SSEClient
+from elasticsearch import Elasticsearch
+
+# Environment variables with defaults
+TOPIC_NAME = os.getenv("TOPIC_NAME", "wikipedia-events")
+KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
+WIKI_STREAM_URL = "https://stream.wikimedia.org/v2/stream/recentchange"
+ES_HOST = os.getenv("ELASTICSEARCH_HOST", "http://elasticsearch:9200")
+
+# Optional Elasticsearch client if needed
+es = Elasticsearch([ES_HOST])
+
+def connect_kafka_producer(retries=5, delay=5):
+    """Initialize Kafka producer with retry logic"""
+    for i in range(retries):
+        try:
+            producer = KafkaProducer(
+                bootstrap_servers=KAFKA_BROKER,
+                value_serializer=lambda v: json.dumps(v).encode("utf-8")
+            )
+            print("✅ Connected to Kafka!")
+            return producer
+        except errors.NoBrokersAvailable as e:
+            print(f"❌ Kafka connection failed ({i+1}/{retries}): {e}")
+            time.sleep(delay)
+    print("🔥 Exiting: No Kafka connection after retries.")
+    return None
+
+def stream_wikipedia_events():
+    """Stream Wikipedia events and send them to Kafka"""
+    producer = connect_kafka_producer()
+    if not producer:
+        return
+
+    print("🔄 Listening to Wikipedia events...")
+    try:
+        response = requests.get(WIKI_STREAM_URL, stream=True)
+        if response.status_code != 200:
+            print(f"❌ Failed to connect to Wikipedia stream: {response.status_code}")
+            return
+
+        client = SSEClient(response)  # <- FIXED LINE
+        
+        for event in client.events():
+            if event.event == "message":
+                try:
+                    if not event.data.strip():
+                        continue
+
+                    change = json.loads(event.data)
+
+                    if change.get("type") == "edit":
+                        print(f"✍ Sending to Kafka: {change['title']} edited by {change['user']}")
+                        future = producer.send(TOPIC_NAME, value=change)
+                        try:
+                            metadata = future.get(timeout=10)
+                            print(f"✅ Message sent: {metadata.topic} | Partition: {metadata.partition} | Offset: {metadata.offset}")
+                        except Exception as e:
+                            print(f"❌ Kafka send error: {e}")
+
+                        producer.flush()
+
+                except json.JSONDecodeError as e:
+                    print(f"⚠️ JSON Decode Error: {e} - Data: {event.data}")
+                    continue
+
+        client.close()
+        producer.close()
+
+    except requests.exceptions.RequestException as e:
+        print(f"❌ Request failed: {e}")
+
+if __name__ == "__main__":
+    stream_wikipedia_events()

--- a/wiki-kafka/wiki_stream_processor/Dockerfile
+++ b/wiki-kafka/wiki_stream_processor/Dockerfile
@@ -1,0 +1,22 @@
+# Base Image with Python 3.9
+FROM python:3.8-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set work directory
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y gcc libpq-dev && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Command to run processor
+CMD ["faust", "-A", "wiki_stream_processor", "worker", "-l", "info"]

--- a/wiki-kafka/wiki_stream_processor/requirements.txt
+++ b/wiki-kafka/wiki_stream_processor/requirements.txt
@@ -1,0 +1,2 @@
+faust==1.10.4
+elasticsearch==7.17.0

--- a/wiki-kafka/wiki_stream_processor/wiki_stream_processor.py
+++ b/wiki-kafka/wiki_stream_processor/wiki_stream_processor.py
@@ -1,0 +1,62 @@
+import os
+from elasticsearch import Elasticsearch, exceptions as es_exceptions
+import faust
+
+# Environment variables with defaults
+KAFKA_BROKER = os.getenv("KAFKA_BROKER", "kafka:9092")
+ES_HOST = os.getenv("ELASTICSEARCH_HOST", "http://elasticsearch:9200")
+TOPIC_NAME = os.getenv("TOPIC_NAME", "wikipedia-events")
+FILTERED_TOPIC_NAME = os.getenv("FILTERED_TOPIC_NAME", "filtered-wikipedia-events")
+ES_INDEX = os.getenv("ES_INDEX", "filtered-wikipedia-events")
+
+# Connect to Elasticsearch with retry
+es = Elasticsearch([ES_HOST])
+
+if es.ping():
+    print("✅ Connected to Elasticsearch!")
+else:
+    print("❌ Elasticsearch connection failed!")
+
+# Faust App initialization
+app = faust.App('wikipedia-processor', broker=f'kafka://{KAFKA_BROKER}')
+
+# Faust Record Schema
+class WikiEvent(faust.Record, serializer='json'):
+    title: str
+    user: str
+    comment: str
+    timestamp: int
+    bot: bool
+    wiki: str
+
+# Define topics
+wiki_topic = app.topic(TOPIC_NAME, value_type=WikiEvent)
+filtered_topic = app.topic(FILTERED_TOPIC_NAME, value_type=WikiEvent)
+
+@app.agent(wiki_topic)
+async def process_wiki(events):
+    async for event in events:
+        try:
+            if not event.bot:
+                await filtered_topic.send(value=event)
+                print(f"✅ Processed and forwarded: {event.title} by {event.user}")
+
+                # Send data to Elasticsearch
+                doc = {
+                    "title": event.title,
+                    "user": event.user,
+                    "comment": event.comment,
+                    "timestamp": event.timestamp,
+                    "wiki": event.wiki
+                }
+                try:
+                    res = es.index(index=ES_INDEX, document=doc)
+                    print(f"📡 Sent to Elasticsearch (ID: {res['_id']}): {event.title}")
+                except es_exceptions.ElasticsearchException as es_err:
+                    print(f"❌ Elasticsearch indexing failed: {es_err}")
+
+        except Exception as e:
+            print(f"⚠️ Processing error: {e}")
+
+if __name__ == '__main__':
+    app.main()


### PR DESCRIPTION
### Summary
This PR introduces the initial project structure for the "wiki-kafka" pipeline, which includes:

- Kafka-based streaming pipeline for wiki data
- Docker Compose setup for local development
- Kubernetes manifests for deployment on Kubernetes clusters
- Producer and stream processor modules (with Dockerfiles and requirements)
- Supporting services like Zookeeper, Kafka Connect, Kafka UI, Elasticsearch, and Kibana

### Changes:
- Added `docker-compose.yml` for local setup.
- Added `Kubernetes deployment YAMLs` for all services.
- Created `wiki_producer` service to produce data into Kafka topics.
- Created `wiki_stream_processor` to consume, process, and stream data further.
- Added `.gitignore` to exclude environment files and system-specific files.

### Next Steps:
- Implement a **Twitter-based producer** to stream live tweets into Kafka.
- Enhance the stream processor to handle Twitter data alongside wiki events.
- Deploy the entire pipeline to a cloud provider (AWS).
